### PR TITLE
Clean up unneeded termination scheme

### DIFF
--- a/bloom/promises/promise_client.rb
+++ b/bloom/promises/promise_client.rb
@@ -17,14 +17,8 @@ class PClient
   bloom do :after_waiting
     all_results <= (results*done).pairs {|r, d| r }
     temp :the_sum <= all_results.group([], sum(all_results.result))
-    vars <+ the_sum {|s| [:sum, s[0]]}
     stdio <~ the_sum {|s| ["All futures complete. Sum is #{s[0]}"]}
   end
-end
-
-def g(x)
-  memo = {}; memo[1] = 1; memo[2] = 1
-  memo[x] ||= g(x-1) + g(x-2)
 end
 
 server = ARGV[0]
@@ -35,10 +29,5 @@ c.tick
 c.sync_do{
   c.promises <+ (1..4).to_a.map {|i| [server, c.ip_port, SecureRandom.uuid, 'lambda{|x| x**2}', i, c.budtime]}
 }
-c.sync_do{
-  c.vars <+ [[:x, g(10)]]
-}
-c.sync_do{
-  c.stdio <~ c.vars.inspected
-}
+
 c.run_fg


### PR DESCRIPTION
This PR removes all references to the "vars" table and "waiting value" in the promises example. The "g(x)" function is also removed as there were no longer any references to it.